### PR TITLE
Minimise Spotify window if it's not minimized when clicking the indicator

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -227,17 +227,17 @@ var SpotifyIndicator = GObject.registerClass(
                     }
 
                     try {
-                        // If 'is_minimized' exists, handle minimization
-                        if (typeof window.is_minimized === 'function') {
-                            if (window.is_minimized()) {
-                                window.unminimize(global.get_current_time());
-                                logDebug('Spotify window unminimized');
-                            }
+                        if (window.minimized) {
+                            window.unminimize();
+                            logDebug("Spotify window unminimized");
+                            // Activate (focus) the window
+                            window.activate(global.get_current_time());
+                            logDebug("Spotify window activated");
+                        } else  {
+                            window?.minimize();
+                            logDebug("Spotify window minimized");
                         }
 
-                        // Activate (focus) the window
-                        window.activate(global.get_current_time());
-                        logDebug('Spotify window activated');
                         spotifyFound = true;
                         break; // Exit the loop once Spotify is found and activated
                     } catch (e) {


### PR DESCRIPTION
The indicator works like a toggle now, if the Spotify window is not minimized it get minimized.

Maybe this would need a setting, IDK.

I have also simplified the logic which seemed to rely on an undocumented function (according to Gjs TypeScript headers).

I would like to know, would you be opposed to move the extension to TypeScript? The only downside is that it involves a build step but it massively improve developer experience.