### PR TITLE
Handle Podcast metadata to show as Artist

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -566,6 +566,18 @@ var SpotifyIndicator = GObject.registerClass(
             let artist = _('Unknown Artist');
             if (Array.isArray(artistArray) && artistArray.length > 0 && artistArray[0].trim() !== '') {
                 artist = artistArray[0];
+            } else {
+                // Possibly a podcast
+
+                // Podcasts have a trackid of /com/spotify/episode and seem to put the
+                // podcast name in the album property
+                let trackid = this._recursiveUnpack(metadata['mpris:trackid']);
+                if (trackid && trackid.startsWith('/com/spotify/episode')) {
+                    let album = this._recursiveUnpack(metadata['xesam:album']);
+                    if (album && album.trim() !== '') {
+                        artist = album;
+                    }
+                }
             }
 
             if (title && title.trim() !== '') {


### PR DESCRIPTION
For whatever reason, Spotify puts the name of a Podcast in the `album` metadata, and leaves everything else empty

<details><summary>Example from DBus</summary>
<p>
<pre>
dbus-send --session --dest=org.mpris.MediaPlayer2.spotify --print-reply /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player string:Metadata
method return time=1746655942.502771 sender=:1.134 -> destination=:1.410 serial=73 reply_serial=2
   variant       array [
         dict entry(
            string "mpris:trackid"
            variant                string "/com/spotify/episode/2J6ChkuMSXYQitzMIclv9s"
         )
         dict entry(
            string "mpris:length"
            variant                uint64 1568130000
         )
         dict entry(
            string "mpris:artUrl"
            variant                string "https://i.scdn.co/image/ab6765630000ba8a2ecbecaf3d7f25ec30a68093"
         )
         dict entry(
            string "xesam:album"
            variant                string "Planet Money"
         )
         dict entry(
            string "xesam:albumArtist"
            variant                array [
                  string ""
               ]
         )
         dict entry(
            string "xesam:artist"
            variant                array [
                  string ""
               ]
         )
         dict entry(
            string "xesam:autoRating"
            variant                double 0
         )
         dict entry(
            string "xesam:discNumber"
            variant                int32 0
         )
         dict entry(
            string "xesam:title"
            variant                string "Planet Money complains. To learn."
         )
         dict entry(
            string "xesam:trackNumber"
            variant                int32 0
         )
         dict entry(
            string "xesam:url"
            variant                string "https://open.spotify.com/episode/2J6ChkuMSXYQitzMIclv9s"
         )
      ]
</pre>
</p>
</details> 

This adds a check to see if the track ID follows the episode format, and if so, uses the `album` value as the `artist`
