### PR TITLE
Add GNOME 49 compatibility to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,10 +6,11 @@
   "preferences": "prefs.js",
   "settings-schema": "org.gnome.shell.extensions.spotify-controls",
   "shell-version": [
-    "45",
-    "46",
-    "47",
-    "48"
+     "45",
+     "46",
+     "47",
+     "48",
+     "49"
   ],
   "url": "https://github.com/Sonath21/spotify-controls",
   "uuid": "spotify-controls@Sonath21",


### PR DESCRIPTION
This pull request updates the [metadata.json](https://github.com/septicwolf818/spotify-controls/blob/copilot/vscode1758711231221/metadata.json) file to include GNOME Shell version 49 in the shell-version array. This resolves the compatibility issue with GNOME 49, allowing the extension to be enabled and function correctly. No further changes were necessary; the extension works as expected after this update.