### PR TITLE
Add max-width setting for song label

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -279,6 +279,38 @@ export default class SpotifyControlsPrefs extends ExtensionPreferences {
 
         displayGroup.add(showTrackInfoSwitch);
 
+        /**
+         * MAXIMUM WIDTH SETTING
+         */
+        const maxWidthRow = new Adw.ActionRow({
+            title: _('Maximum Width (pixels)'),
+            subtitle: _('Limit how wide the extension label can be in the top bar (0 = no limit)'),
+        });
+
+        const maxWidthAdjustment = new Gtk.Adjustment({
+            lower: 0,
+            upper: 1000,
+            step_increment: 10,
+            page_increment: 50,
+        });
+
+        const maxWidthSpin = new Gtk.SpinButton({
+            adjustment: maxWidthAdjustment,
+            numeric: true,
+        });
+
+        settings.bind(
+            'max-width',
+            maxWidthSpin,
+            'value',
+            Gio.SettingsBindFlags.DEFAULT
+        );
+
+        maxWidthRow.add_suffix(maxWidthSpin);
+        maxWidthRow.activatable_widget = maxWidthSpin;
+
+        displayGroup.add(maxWidthRow);
+
         // Add the display group to the page
         page.add(displayGroup);
 

--- a/schemas/org.gnome.shell.extensions.spotify-controls.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.spotify-controls.gschema.xml
@@ -62,5 +62,13 @@
         If un-toggled, clicking the extension again while Spotify is on top does nothing.
       </description>
     </key>
+    <key name="max-width" type="i">
+      <default>0</default>
+      <summary>Maximum width for the extension label</summary>
+      <description>
+        Sets the maximum width, in pixels, that the Spotify Controls label is allowed to occupy in the top bar.
+        A value of 0 or a negative value disables the limit and allows the label to take its natural width.
+      </description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Fix for #16 

Added a setting to control the length of the song label. You can now adjust the maximum width from 1px to 1000px. If the title is too long for the chosen size, it will automatically cut off and show ... at the end.